### PR TITLE
don't write newline at end of fpgm/prep and revert test data changes

### DIFF
--- a/Lib/fontTools/ttLib/tables/_f_p_g_m.py
+++ b/Lib/fontTools/ttLib/tables/_f_p_g_m.py
@@ -15,7 +15,6 @@ class table__f_p_g_m(DefaultTable.DefaultTable):
 
 	def toXML(self, writer, ttFont):
 		self.program.toXML(writer, ttFont)
-		writer.newline()
 
 	def fromXML(self, name, attrs, content, ttFont):
 		program = ttProgram.Program()

--- a/Lib/fontTools/ttLib/tables/_g_l_y_f.py
+++ b/Lib/fontTools/ttLib/tables/_g_l_y_f.py
@@ -371,10 +371,13 @@ class Glyph(object):
 				writer.newline()
 			haveInstructions = self.numberOfContours > 0
 		if haveInstructions:
-			writer.begintag("instructions")
-			writer.newline()
-			self.program.toXML(writer, ttFont)
-			writer.endtag("instructions")
+			if self.program:
+				writer.begintag("instructions")
+				writer.newline()
+				self.program.toXML(writer, ttFont)
+				writer.endtag("instructions")
+			else:
+				writer.simpletag("instructions")
 			writer.newline()
 
 	def fromXML(self, name, attrs, content, ttFont):

--- a/Lib/fontTools/ttLib/tables/_g_l_y_f.py
+++ b/Lib/fontTools/ttLib/tables/_g_l_y_f.py
@@ -354,12 +354,7 @@ class Glyph(object):
 		if self.isComposite():
 			for compo in self.components:
 				compo.toXML(writer, ttFont)
-			if hasattr(self, "program"):
-				writer.begintag("instructions")
-				writer.newline()
-				self.program.toXML(writer, ttFont)
-				writer.endtag("instructions")
-				writer.newline()
+			haveInstructions = hasattr(self, "program")
 		else:
 			last = 0
 			for i in range(self.numberOfContours):
@@ -374,12 +369,13 @@ class Glyph(object):
 				last = self.endPtsOfContours[i] + 1
 				writer.endtag("contour")
 				writer.newline()
-			if self.numberOfContours:
-				writer.begintag("instructions")
-				writer.newline()
-				self.program.toXML(writer, ttFont)
-				writer.endtag("instructions")
-				writer.newline()
+			haveInstructions = self.numberOfContours > 0
+		if haveInstructions:
+			writer.begintag("instructions")
+			writer.newline()
+			self.program.toXML(writer, ttFont)
+			writer.endtag("instructions")
+			writer.newline()
 
 	def fromXML(self, name, attrs, content, ttFont):
 		if name == "contour":

--- a/Tests/subset/data/TestCLR-Regular.ttx
+++ b/Tests/subset/data/TestCLR-Regular.ttx
@@ -442,8 +442,7 @@
         <pt x="265" y="633" on="1"/>
         <pt x="66" y="633" on="1"/>
       </contour>
-      <instructions>
-        <assembly>
+      <instructions><assembly>
           PUSH[ ]	/* 2 values pushed */
           1 0
           MDAP[1]	/* MoveDirectAbsPt */
@@ -477,8 +476,7 @@
           1 2 0
           MIRP[01101]	/* MoveIndirectRelPt */
           SHP[0]	/* ShiftPointByLastPoint */
-        </assembly>
-      </instructions>
+        </assembly></instructions>
     </TTGlyph>
 
     <TTGlyph name=".null"/><!-- contains no outline data -->
@@ -490,10 +488,8 @@
         <pt x="305" y="0" on="1"/>
         <pt x="100" y="0" on="1"/>
       </contour>
-      <instructions>
-        <assembly>
-        </assembly>
-      </instructions>
+      <instructions><assembly>
+        </assembly></instructions>
     </TTGlyph>
 
     <TTGlyph name="b" xMin="100" yMin="0" xMax="305" yMax="205">
@@ -503,10 +499,8 @@
         <pt x="305" y="0" on="1"/>
         <pt x="100" y="0" on="1"/>
       </contour>
-      <instructions>
-        <assembly>
-        </assembly>
-      </instructions>
+      <instructions><assembly>
+        </assembly></instructions>
     </TTGlyph>
 
     <TTGlyph name="c" xMin="100" yMin="0" xMax="305" yMax="205">
@@ -516,10 +510,8 @@
         <pt x="305" y="0" on="1"/>
         <pt x="100" y="0" on="1"/>
       </contour>
-      <instructions>
-        <assembly>
-        </assembly>
-      </instructions>
+      <instructions><assembly>
+        </assembly></instructions>
     </TTGlyph>
 
     <TTGlyph name="nonmarkingreturn"/><!-- contains no outline data -->
@@ -585,10 +577,8 @@
         <pt x="354" y="430" on="0"/>
         <pt x="320" y="430" on="0"/>
       </contour>
-      <instructions>
-        <assembly>
-        </assembly>
-      </instructions>
+      <instructions><assembly>
+        </assembly></instructions>
     </TTGlyph>
 
     <TTGlyph name="smileface.84380d" xMin="238" yMin="181" xMax="761" yMax="606">
@@ -632,10 +622,8 @@
         <pt x="354" y="430" on="0"/>
         <pt x="320" y="430" on="0"/>
       </contour>
-      <instructions>
-        <assembly>
-        </assembly>
-      </instructions>
+      <instructions><assembly>
+        </assembly></instructions>
     </TTGlyph>
 
     <TTGlyph name="smileface.e59b25" xMin="100" yMin="0" xMax="900" yMax="800">
@@ -659,10 +647,8 @@
         <pt x="653" y="770" on="0"/>
         <pt x="347" y="770" on="0"/>
       </contour>
-      <instructions>
-        <assembly>
-        </assembly>
-      </instructions>
+      <instructions><assembly>
+        </assembly></instructions>
     </TTGlyph>
 
     <TTGlyph name="smileface.ffe08a" xMin="100" yMin="0" xMax="900" yMax="800">
@@ -676,10 +662,8 @@
         <pt x="666" y="0" on="0"/>
         <pt x="334" y="0" on="0"/>
       </contour>
-      <instructions>
-        <assembly>
-        </assembly>
-      </instructions>
+      <instructions><assembly>
+        </assembly></instructions>
     </TTGlyph>
 
   </glyf>

--- a/Tests/subset/data/expect_keep_colr.ttx
+++ b/Tests/subset/data/expect_keep_colr.ttx
@@ -36,8 +36,7 @@
         <pt x="666" y="0" on="0"/>
         <pt x="334" y="0" on="0"/>
       </contour>
-      <instructions>
-      </instructions>
+      <instructions/>
     </TTGlyph>
 
     <TTGlyph name="glyph00003" xMin="100" yMin="0" xMax="900" yMax="800">
@@ -61,8 +60,7 @@
         <pt x="653" y="770" on="0"/>
         <pt x="347" y="770" on="0"/>
       </contour>
-      <instructions>
-      </instructions>
+      <instructions/>
     </TTGlyph>
 
     <TTGlyph name="glyph00004" xMin="238" yMin="181" xMax="761" yMax="606">
@@ -106,8 +104,7 @@
         <pt x="354" y="430" on="0"/>
         <pt x="320" y="430" on="0"/>
       </contour>
-      <instructions>
-      </instructions>
+      <instructions/>
     </TTGlyph>
 
     <TTGlyph name="smileface" xMin="100" yMin="0" xMax="900" yMax="800">
@@ -171,8 +168,7 @@
         <pt x="354" y="430" on="0"/>
         <pt x="320" y="430" on="0"/>
       </contour>
-      <instructions>
-      </instructions>
+      <instructions/>
     </TTGlyph>
 
   </glyf>


### PR DESCRIPTION
It wasn't necessary to modify subset/data/TestCLR-Regular.ttx, as that's only used for loading the input data, not for comparing the resulting output XML, so I reverted that.

The fpgm/prep should not contain an extra newline at the end, as that's now implied in Program.toXML.

I'm still not sure about simplifying `<instructions></instructions>` with `<instructions/>`, let's wait to see what the others say.

